### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ TODO
 Unexpected behaviors
 ---_--
 
-- printf string without `\n`: newline charactor will be used to flush the stdout to the terminal, therefore if the printf string does not end with `\n`, the string will not be immediately output to the console. See testcase No. `0000`.
+- printf string without `\n`: newline character will be used to flush the stdout to the terminal, therefore if the printf string does not end with `\n`, the string will not be immediately output to the console. See testcase No. `0000`.
 - When deploy on Aliyun Cloud, LLDB will suffer an run fail issue in _start function after loading the binary and start to run it  


### PR DESCRIPTION
@dc951015, I've corrected a typographical error in the documentation of the [OnlineCTutor](https://github.com/dc951015/OnlineCTutor) project. Specifically, I've changed charactor to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
